### PR TITLE
Allow icon to be customised through config

### DIFF
--- a/src/MenuBuilder.php
+++ b/src/MenuBuilder.php
@@ -25,7 +25,7 @@ class MenuBuilder extends Tool
         // Outl1ne\MenuBuilder\MenuBuilder::getMenuResource()::authorizedToViewAny(request())
         return MenuSection::make(__('novaMenuBuilder.sidebarTitle'))
             ->path('/menus')
-            ->icon('adjustments');
+            ->icon(config('nova-menu.icon','adjustments'));
     }
 
     /** @noinspection PhpUnhandledExceptionInspection */


### PR DESCRIPTION
This change keeps the icon as it is by default, but would optionally allow it to be customised in the config file.

My reason for suggesting this change is that currently the icon is the same as that used by the nova settings package.