### PR TITLE
Add support for HasUuids.

### DIFF
--- a/src/Http/Controllers/MenuController.php
+++ b/src/Http/Controllers/MenuController.php
@@ -123,7 +123,7 @@ class MenuController extends Controller
         $menuItemModel = MenuBuilder::getMenuItemClass();
 
         $data = $request->getValues();
-        $data['order'] = $menuItemModel::max('id') + 1;
+        $data['order'] = $menuItemModel::max('order') + 1;
 
         $model = new $menuItemModel;
         foreach ($data as $key => $value) {


### PR DESCRIPTION
Due to the way ordering is currently implemented, a "non-numeric value encountered" exception will be thrown when using the HasUuids trait (and tweaking the migrations).

To fix this, instead of `max`ing on the ID, which will then be non-numeric, `max` on the order column instead. This will work as when there's no previous menu items, the `max` call will result in 0, which is then incremented by 1.

Please note that this is a relatively 'dirty' fix which needs more in-depth testing. I have already ensured this work on depths -- it seems to behave the same as using IDs.

An alternative way of implementing this is using `getKeyType() === 'int'` to ensure the ID is numeric, then implementing further logic to make ordering work as it currently does.