### PR TITLE
feat: add ability to have custom display for locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,27 @@ public static function getData($data = null)
 }
 ```
 
+### Custom locale display
+
+To customize the locale display you can use `Nova::provideToScript` to pass `customLocaleDisplay` as in the example below.
+
+```php
+// in app/Providers/NovaServiceProvider.php
+
+public function boot()
+{
+    Nova::serving(function () {
+        Nova::provideToScript([
+            // ...
+            'customLocaleDisplay' => [
+                'en' => <img src="/flag-en.png"/>,
+                'et' => <img src="/flag-et.png"/>,
+            ]
+        ]);
+    });
+}
+```
+
 ### Returning the menus in a JSON API
 
 #### nova_get_menus()

--- a/resources/js/components/core/MenuBuilderHeader.vue
+++ b/resources/js/components/core/MenuBuilderHeader.vue
@@ -15,7 +15,7 @@
         }"
         style="border-bottom-width: 2px"
       >
-        <span> {{ locales[locale] }} ({{ locale }}) </span>
+        <span v-html="getLocaleDisplay(locale)" />
       </div>
     </div>
 
@@ -62,6 +62,18 @@ export default {
       return localeCount > 1 || this.menuCount > 1;
     },
   },
+
+  methods: {
+    getLocaleDisplay(locale) {
+      const customDisplay = Nova.config('customLocaleDisplay');
+
+      if (customDisplay && customDisplay[locale]) {
+        return customDisplay[locale];
+      }
+
+      return `${this.locales[locale]} (${locale})`;
+    },
+  }
 };
 </script>
 


### PR DESCRIPTION
This PR adds ability to customise display of locales as show in the image:

![image](https://github.com/user-attachments/assets/6a0d5317-b1ad-4f2a-9b74-5415c3df1384)

You just have to provide to script a custom config `customLocaleDisplay `, this way this config can also be used for the same purpose on other packages like [outl1ne/nova-page-manager](https://github.com/outl1ne/nova-page-manager) and also [outl1ne/nova-translatable](https://github.com/outl1ne/nova-translatable)