### PR TITLE
nova 5 support. minimal changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@vue/babel-plugin-jsx": "^1.1.1",
     "axios": "^1.6.0",
     "cross-env": "^7.0.3",
-    "form-backend-validation": "^2.4.0",
     "laravel-nova-devtool": "file:vendor/laravel/nova-devtool",
     "laravel-nova-ui": "^0.4.12",
     "prettier": "^2.7.1",

--- a/resources/js/components/modals/UpdateMenuItemModal.vue
+++ b/resources/js/components/modals/UpdateMenuItemModal.vue
@@ -198,7 +198,7 @@
 
 <script>
 import { HandlesValidationErrors } from 'laravel-nova';
-import { Errors } from 'form-backend-validation';
+import { Errors } from 'laravel-nova';
 import { Button } from 'laravel-nova-ui';
 import Multiselect from 'vue-multiselect/src/Multiselect';
 


### PR DESCRIPTION
## Summary

  Fix Nova 5 compatibility by replacing deprecated
  form-backend-validation with laravel-nova Errors
  class.

  ## Changes

  - Replace `form-backend-validation` import with
  `laravel-nova` in UpdateMenuItemModal.vue
  - Remove `form-backend-validation` dependency from
  package.json
  - Update package-lock.json accordingly

  ## Background

  As documented in the [Nova 5 upgrade
  guide](https://nova.laravel.com/docs/v5/upgrade#repla
  cing-form-backend-validation), the
  `form-backend-validation` repository has been
  archived and should be replaced with Laravel Nova's
  built-in `Errors` class.

  This is a minimal, focused fix that addresses Nova 5
  compatibility without introducing unrelated changes.
  While PR #215 contains Nova 5 support, it has been
  stalled for 6 months with multiple unaddressed review
   comments and extensive changes beyond the core
  compatibility issue.

closes #214 

  ## Testing

  ✅ Tested with Laravel Nova 5
  ✅ All existing functionality preserved
  ✅ No breaking changes introduced

  ## References

  - Nova 5 Upgrade Guide: https://nova.laravel.com/docs
  /v5/upgrade#replacing-form-backend-validation